### PR TITLE
Update README.md to include steps for Linux devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ While this works well on many websites, this is a very early state of this featu
     - In MicaForEveryone add a new process rule and select "zen"
     - Activate **Blur Behind** and set the Backdrop Type to **Acrylic**
 
+#### Linux
+1. Open Zen Browser and go to `about:config`. Ensure the installed version of Zen is above release **1.11.2b**
+2. Make sure that `browser.tabs.allow_transparent_browser` and `zen.widget.linux.transparency` are set to **true**
+3. For a blurred window with **KDE PLASMA**, install [kwin-effects-forceblur](https://github.com/taj-ny/kwin-effects-forceblur) through your system repository, or build from source
+    - Follow steps shown on the project Github to enable blur, and add `zen` to the allowlist
+
 ##### TODO: Add other OS prerequisites
 
 ## Installation


### PR DESCRIPTION
Adds the process for a transparent browser under Linux devices, as well as enabling blur under a KDE plasma install.

I do not know the process for blurring windows on other desktop environments, but these are the exact steps I've used for a blurred look not unlike what is seen on MacOS devices.

![image](https://github.com/user-attachments/assets/526ec37f-7f2e-42df-88ef-b0c1715b6ae8)
