### PR TITLE
Improve azure devops self-hosted transparency

### DIFF
--- a/src/main/transparent-zen.ts
+++ b/src/main/transparent-zen.ts
@@ -206,6 +206,23 @@ class TransparentZen {
 		let nextDepth = depth;
 		let isInsideOverlay = insideOverlay;
 
+		// Set Azure DevOps specific CSS properties
+		if (currentElement === document.body)
+		{
+			if (currentElement.className.includes('ms-vss-web-vsts')) {
+				const root = document.documentElement;
+
+				root.style.setProperty('--palette-neutral-0', '0, 0, 0, 0');
+				root.style.setProperty('--palette-neutral-2', '0, 0, 0, 0');
+				root.style.setProperty('--palette-neutral-4', '0, 0, 0, 0');
+				root.style.setProperty('--palette-neutral-6', '0, 0, 0, 0');
+				root.style.setProperty('--palette-neutral-8', '0, 0, 0, 0');
+				root.style.setProperty('--palette-neutral-10', '0, 0, 0, 0');
+
+				console.info('Azure DevOps detected - Applied transparent palette');
+			}
+		}
+		
 		if (currentElement.tagName === "A") {
 			currentElement.dataset.tzProcessed = "true";
 			currentElement.dataset.tzAnchor = "true";


### PR DESCRIPTION
Improve setting transparent backgrounds on azure devops self-hosted instances. These don't follow any given URL scheme, but can be identified by their body element having a class name like "ms-vss-web-vsts-theme-dark". To make transparency work significantly better (still not perfectly) on these pages, we can override the palette neutral colors when the page's body loads or is refreshed.

Before changes:
![image](https://github.com/user-attachments/assets/0d552689-f8a3-4967-9999-cb4a63330157)

After changes:
![image](https://github.com/user-attachments/assets/2e1f72d9-2e67-4265-bd68-e30980178b99)
