### PR TITLE
Fix styles not applying to tabs loaded in background.

### DIFF
--- a/src/worker/background.ts
+++ b/src/worker/background.ts
@@ -24,13 +24,11 @@ browser.runtime.onMessage.addListener((message: Message) => {
 });
 
 async function applyStyles(filePath?: string, domains?: Array<string>) {
-	const tabs = await browser.tabs.query({});
-	const current_window = await browser.windows.getCurrent();
+	const tabs = await browser.tabs.query({currentWindow: true});
 
 	for (const tab of tabs) {
 		if (!tab.id || !tab.url) continue;
 		if (tab.discarded) continue;
-		if (tabs.length > 20 && tab.windowId !== current_window.id) continue;
 		if (tabs.length > 40 && !tab.active) continue;
 		if (domains) {
 			for (const domain of domains) {


### PR DESCRIPTION
Tabs opened in the background were not being included when applying styles, including ones that were unloaded to save memory. I'm not sure if the decision to not query them was intentional, but I removed the query parameters and found no significant impact on performance. Filtration gets restored at a high number of tabs.