### PR TITLE
fix: github code editor and dashboard

### DIFF
--- a/styles/websites/github.css
+++ b/styles/websites/github.css
@@ -130,3 +130,7 @@ div.prc-Dialog-Dialog-luvDS,
 .cm-editor,.cm-gutters,.cm-content {
    background: transparent !important;
 }
+
+.feed-background {
+    background-color: transparent !important;
+}

--- a/styles/websites/github.css
+++ b/styles/websites/github.css
@@ -126,3 +126,7 @@ div.prc-Dialog-Dialog-luvDS,
     }
   }
 }
+
+.cm-editor,.cm-gutters,.cm-content {
+   background: transparent !important;
+}

--- a/styles/websites/github.css
+++ b/styles/websites/github.css
@@ -7,7 +7,6 @@ body {
   --page-header-bgColor: var(--transparent-background);
   --overlay-bgColor: var(--transparent-background-darker);
   --button-default-bgColor-rest: var(--transparent-background-dark);
-
   background: none !important;
 }
 
@@ -128,9 +127,13 @@ div.prc-Dialog-Dialog-luvDS,
 }
 
 .cm-editor,.cm-gutters,.cm-content {
-   background: transparent !important;
+  background: transparent !important;
 }
 
 .feed-background {
-    background-color: transparent !important;
+  background-color: transparent !important;
+}
+
+.TimelineItem-badge {
+  background-color: transparent;
 }


### PR DESCRIPTION
Before this patch

<img width="3840" height="2076" alt="图片" src="https://github.com/user-attachments/assets/88362b7a-9d1b-40af-89af-e9934bce4019" />

<img width="3840" height="2076" alt="图片" src="https://github.com/user-attachments/assets/e26bf195-1e9b-4ca9-a850-e9e417a50e9f" />

<img width="711" height="365" alt="图片" src="https://github.com/user-attachments/assets/c6ffb638-7e49-4d98-97b6-a69b07c02915" />


After this patch

<img width="3840" height="2076" alt="图片" src="https://github.com/user-attachments/assets/70964490-6ea3-4383-bce5-2d8cb5771af0" />

<img width="3840" height="2076" alt="图片" src="https://github.com/user-attachments/assets/ac68c1f4-a2f9-46bb-b351-16450791b3b7" />

<img width="691" height="370" alt="图片" src="https://github.com/user-attachments/assets/579f2ad4-d3a1-473d-abab-85da2604e94b" />


---

I noticed that the development branch is currently 20 commits behind master, so I opened this PR targeting master directly for now. If you would prefer, I can retarget it to development.