### PR TITLE
 feat: add support for gemini.google.com

### DIFF
--- a/data/ContentScripts.json
+++ b/data/ContentScripts.json
@@ -188,6 +188,12 @@
       "css": ["./styles/websites/discord.css"],
       "run_at": "document_start",
       "favicon": "https://icons.duckduckgo.com/ip3/www.discord.com.ico"
+    },{
+      "name": "Google Gemini",
+      "matches": ["[^ ]*://gemini.google.com/[^ ]*"],
+      "css": ["./styles/websites/gemini.google.css"],
+      "run_at": "document_start",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/1/1d/Google_Gemini_icon_2025.svg"
     }
   ]
 }

--- a/styles/websites/gemini.google.css
+++ b/styles/websites/gemini.google.css
@@ -1,0 +1,25 @@
+@import url("../shared/base.css");
+
+:root,
+:where(.theme-host):where(.dark-theme) {
+  --bard-color-synthetic--chat-window-surface: var(--transparent-background-dark);
+  --gem-sys-color--on-surface: var(--color-text);
+  --gem-sys-color--surface: var(--transparent-background);
+  --gem-sys-color--surface-bright: var(--transparent-background);
+  --gem-sys-color--surface-container: var(--transparent-background-dark);
+  --gem-sys-color--surface-container-high: var(--transparent-background-darker);
+  color: var(--color-text);
+}
+
+input-container::before {
+  background: (180deg, var(--transparent-background-dark), var(--transparent-background)) !important;
+
+}
+
+code {
+  background: var(--transparent-background-dark);
+}
+
+.immersives-mode {
+  background-color: #00000000 !important;
+}

--- a/styles/websites/gemini.google.css
+++ b/styles/websites/gemini.google.css
@@ -2,7 +2,7 @@
 
 :root,
 :where(.theme-host):where(.dark-theme) {
-  --bard-color-synthetic--chat-window-surface: var(--transparent-background-dark);
+  --bard-color-synthetic--chat-window-surface: #00000000 !important;
   --gem-sys-color--on-surface: var(--color-text);
   --gem-sys-color--surface: var(--transparent-background);
   --gem-sys-color--surface-bright: var(--transparent-background);


### PR DESCRIPTION
This PR adds official support for Google Gemini (gemini.google.com), applying custom transparent styling to the chat interface.

  Key Changes
   - New Stylesheet: Created styles/websites/gemini.google.css to handle Gemini's unique UI structure.
       - Adjusted surfaces, containers, and chat windows using the extension's standard transparency variables.
       - Applied transparency to code blocks and the immersive mode background.
   - Site Registration: Added Gemini to data/ContentScripts.json with appropriate URL matching and the updated 2025 Gemini icon.

  Implementation Details
   - Targeted :where(.theme-host):where(.dark-theme) to ensure seamless integration with Gemini's native dark mode.
   - Overrode internal CSS variables (like --gem-sys-color--surface) to maintain layout consistency while removing opaque backgrounds.