### PR TITLE
Adapted duckduckgo header transparency

### DIFF
--- a/styles/websites/duckduckgo.css
+++ b/styles/websites/duckduckgo.css
@@ -48,7 +48,7 @@ body.embedded-search-default-theme .newtab-heading {
 }
 
 .header-wrap {
-  background-color: var(--transparent-background-darker) !important;
+  background-color: var(--transparent-background) !important;
   backdrop-filter: var(--backdrop-blur);
   box-shadow: none !important;
 


### PR DESCRIPTION
changed .header-wrap background-color to use var(--transparent-backgound) instead of var(--transparent-background-darker).